### PR TITLE
Mention method for avoiding manual analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Little Bank is a framework for analyzing financial transactions.
 - All analysis should be a matter of summarizing credit, debit or balance of an account
   in a system. The intention is to reduce bugs by making all analysis use the same
   numerical implementation.
-- This means that we're of the opinion that implementing filters and doing arithmetic
-  on transactions outside of little-bank code is _wrong_. If we find ourselves grasping
-  to do this, what we should instead do is introduce new accounts our possibly
-  restructure the flow between the existing ones.
+- This means that we're of the opinion that implementing filters and doing arithmetic on
+  transactions outside of little-bank code is _wrong_. If we find ourselves grasping to
+  do this, what we should instead do is introduce new accounts our possibly restructure
+  the flow between the existing ones.
 - Allow defining rules for a system in a declarative way.
 - Disallow mutation. The design encourages immutable, append-only transactions.
 - All operations that update the system are very similar: appending transactions which


### PR DESCRIPTION
As an example, let's say we want to be able to count funds coming in based on a new dimension. We start with funds simply flowing in one direction between two accounts A and B. Let's say A is customer funds and B is our bank account.

```
A -> B
```

Now we want differentiate on PSP and be able to see how much of the customer funds came from each. Being used to imperative code it's easy to grasp for just doing the analysis manually:

```
psp_a = sum([txn.value for txn in txns if txn.psp is PSP.A])
```

What we should really do here though is question the structure of accounts. By introducing two new accounts to represent our two PSPs, we can introduce a new structure like this:

```
A ─┬─> PSP A ─┬─> B
   └─> PSP B ─┘
```

And now we can inspect the money that flows through the new accounts, in this case by inspecting `credit` on the PSP A and PSP B accounts.

In order to maintain the same "transactional integrity" as we started out with, e.g. a deduction on A is always an increase on B, we can introduce rules to our system doing two things:

- Require the balance of the PSP accounts to always be zero. This means that if you add a transaction with PSP A or B as credit, you must balance it out with a transaction with PSP A or B as debit.
- Limiting between which accounts transactions may flow. We can setup rules that dictate that PSP A and B can only interact with A and B.